### PR TITLE
Catch error messages returned by API

### DIFF
--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -44,6 +44,10 @@ export const POST: RequestHandler = async ({ request }) => {
 				input: reqMessages[reqMessages.length - 1].content
 			})
 		})
+		if (!moderationRes.ok) {
+			const err = await moderationRes.json()
+			throw new Error(err.error.message)
+		}
 
 		const moderationData = await moderationRes.json()
 		const [results] = moderationData.results
@@ -83,7 +87,7 @@ export const POST: RequestHandler = async ({ request }) => {
 
 		if (!chatResponse.ok) {
 			const err = await chatResponse.json()
-			throw new Error(err)
+			throw new Error(err.error.message)
 		}
 
 		return new Response(chatResponse.body, {


### PR DESCRIPTION
Errors returned by the api aren't currently being caught in a try catch block. 

Also `err.error.message` will give the error message returned by the api instead of [object, object] in the terminal console.

example error response 
```
{
  error: {
    message: 'You exceeded your current quota, please check your plan and billing details.',
    type: 'insufficient_quota',
    param: null,
    code: null
  }
}
```
